### PR TITLE
squash GCC -Wimplicit-fallthrough warnings

### DIFF
--- a/filereader.h
+++ b/filereader.h
@@ -159,18 +159,21 @@ static inline void* file_src_thread_func(void *obj){
 						_read = fc->_read = _read_data_file;
 						_close = fc->_close = NULL;
 					}
+					// fall through
 				case FILEREADER_ATTR_PROC:
 					if(_file == NULL){
 						_file = fc->_file = popen(fc->filename, "r");
 						_read = fc->_read = _read_data_file;
 						_close = fc->_close = _close_input_proc;
 					}
+					// fall through
 				case FILEREADER_ATTR_USER:
 					if(_file == NULL){
 						_file = fc->_file;
 						_read = fc->_read;
 						_close = fc->_close;
 					}
+					// fall through
 				default:
 					if(_file == NULL){
 						_file = fc->_file = open_file_for_read(fc->filename, NULL);

--- a/mem_share.h
+++ b/mem_share.h
@@ -793,10 +793,12 @@ static inline size_t mem_size_obj(void *obj, uint8_t mem_type, const obj_desc_t 
 	if(obj == NULL) return size;
 	switch(mem_type){
 		case 3: size += mem_size_round(sizeof(void*) * cnt);
+		// fall through
 		case 2:
 			for(m=0;m<cnt;m++) if(((void**)obj)[m]) size += mem_size_round(desc->size);
 			break;
 		case 1: size += mem_size_round(cnt * desc->size); // TODO: if desc == &OBJ_DESC_DATA, mem_size_round may waste many memory
+		// fall through
 		case 0: break;
 	}
 	if(desc->n_child == 0) return size;
@@ -915,17 +917,15 @@ static inline size_t mem_load_obj(void *obj, size_t aux_data, uint8_t mem_type, 
 		}
 	}
 	if(desc->n_child == 0 && desc->post == NULL){
-		switch(mem_type){
-			case 2:
-			case 3:
-				for(m=0;m<cnt;m++){
-					ptr = ((void**)obj) + m;
-					if(*ptr == NULL) continue;
-					*ptr = (void*)addr;
-					addr += mem_size_round(desc->size);
-				}
-			default: return addr;
+		if(mem_type == 2 || mem_type == 3){
+			for(m=0;m<cnt;m++){
+				ptr = ((void**)obj) + m;
+				if(*ptr == NULL) continue;
+				*ptr = (void*)addr;
+				addr += mem_size_round(desc->size);
+			}
 		}
+		return addr;
 	}
 	for(m=0;m<cnt;m++){
 		if(mem_type & 0x02){

--- a/wtpoa-cns.c
+++ b/wtpoa-cns.c
@@ -110,7 +110,7 @@ int main(int argc, char **argv){
 		switch(c){
 			case 'h': return usage();
 			case 't': ncpu = atoi(optarg); break;
-			case 'p': print_lay = 1;
+			case 'p': print_lay = 1; // fall through
 			case 'd': push_cplist(dbfs, optarg); break;
 			case 'u': flags = atoi(optarg); break;
 			case 'r': par.refmode = 1; break;


### PR DESCRIPTION
GCC 7 added -Wimplicit-fallthrough that warns when a non-empty switch case has
no break. This is enabled by -Wall.