### PR TITLE
added SAM cleaning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 ## <a name="start"></a>Getting Started
+
+This fork will clean the SAM file created by minimap2 polishing step
+of the ```wtdbg2.pl``` script to keep only reads with "rl" tag in the last column.
+
+The ```-m``` option is now active.
+
 ```sh
 git clone https://github.com/ruanjue/wtdbg2
 cd wtdbg2 && make

--- a/wtdbg2.pl
+++ b/wtdbg2.pl
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Std;
 
 my %opts = (t=>4, m=>"2g");
-getopts('t:x:o:a:g:X:M:OPp:k:', \%opts);
+getopts('t:m:x:o:a:g:X:M:OPp:k:', \%opts);
 die (qq/Usage: wtdbg2.pl [options] <reads.fa>
 Options:
   -o STR     output prefix [first input]
@@ -63,7 +63,7 @@ my @lines = ();
 push(@lines, qq/$opts{asm} $asm_opt/);
 push(@lines, qq/$opts{cns} -t $opts{t} -i $prefix.ctg.lay.gz -fo $prefix.raw.fa/);
 unless (defined $opts{P}) {
-	push(@lines, qq/$opts{mm2} -ax $opts{M} -t$opts{t} -r2k $prefix.raw.fa $mm2_input | $opts{smt} sort -m $opts{m} -\@$smt_threads -o $prefix.bam/);
+	push(@lines, qq/$opts{mm2} -ax $opts{M} -t$opts{t} -r2k $prefix.raw.fa $mm2_input | awk -v "OFS=\t" '{if(substr($1,1,1) == "@" ) print $0; else if(substr($NF,1,2) == "rl") print $0}' | $opts{smt} sort -m $opts{m} -\@$smt_threads -o $prefix.bam/);
 	push(@lines, qq/$opts{smt} view -F0x900 $prefix.bam | $opts{cns} -t $opts{t} -d $prefix.raw.fa -i - -fo $prefix.cns.fa/);
 }
 


### PR DESCRIPTION
Hi,
due to some minimap2 truncated reads in the minimap2 polishing step of the wtdbg2.pl script,
I have added a simple awk pipe to get rid of these lines.
Since all of the produced wtbdg2.pl minimap2 polishing reads have the "rl" tag on the last column, I hope that this hack is valid.
I also added the "m" option to be bale to define the samtools -M
Best regards
Kristian